### PR TITLE
Allow random colors in borderColor array

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const getBorderColors = (colors = 'random') => {
   colors = [].concat(colors) // ensure colors is an array
              .map(getColor);  // before mapping
 
+  // hack to repeat color for a single color border and still use 'linear-gradient'
   return colors.length < 2 ? colors.concat(colors[0]) : colors;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,22 +1,20 @@
+const randomColor = ()  => '#'+Math.floor(Math.random()*16777215).toString(16);
+const getColor = (input) => input.toLowerCase() === 'random' ? randomColor() : input;
+
+const getBorderColors = (colors = 'random') => {
+  colors = [].concat(colors) // ensure colors is an array
+             .map(getColor);  // before mapping
+
+  return colors.length < 2 ? colors.concat(colors[0]) : colors;
+}
+
 module.exports.decorateConfig = (config) => {
   var configObj = Object.assign({
     borderWidth: '4px',
     borderColors: ['#fc1da7', '#fba506']
   }, config.hyperBorder);
 
-  if(typeof configObj.borderColors === 'string'
-  && configObj.borderColors.toLowerCase() === 'random') {
-    var randomColor = function() {
-      return '#'+Math.floor(Math.random()*16777215).toString(16);
-    };
-
-    configObj.borderColors = [
-      randomColor(),
-      randomColor()
-    ];
-  }
-
-  var colors = configObj.borderColors.join(',');
+  var colors = getBorderColors(configObj.borderColors).join(',');
   var borderWidth = configObj.borderWidth;
   return Object.assign({}, config, {
     css: `


### PR DESCRIPTION
Hi there. First of all, good work on this fun little project!

I'm not sure if you're looking for these kinds of changes, but they enabled my to do what I wanted to do with this project.

Border settings this enables:
```
borderColors: '#fff' // white border
borderColors: 'random',  // border of one random color
borderColors: ['random', '#fff'],  // random now works within this array
borderColors: ['random'],  // same as 2nd example
```

Of course, this breaks how `borderColors: 'random'` worked previously, since that would create a gradient of two random colors, and now it would only be a single solid-color border.

If it's preferable to keep that behavior, `line 8` could be change to:
```
return colors.length < 2 ? colors.concat('random') : colors;
```