### PR TITLE
Add a configurable angle for the linear-gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module.exports = {
 Then every newly opened HyperTerm window will have a different colored border.
 
 ### Animate Border Colors
-You like some animations? Than try this:
+You like some animations? Then try this:
 
 ```javascript
 module.exports = {
@@ -62,6 +62,22 @@ module.exports = {
     ...
     hyperBorder: {
       animate: true,
+      ...
+    }
+    ...
+  }
+}
+```
+
+## Angled Gradients
+Because we use CSS3's `linear-gradient`, we're able to specify angles at which to create the radius. Set your own angle like this: 
+
+```javascript
+module.exports = {
+  config: {
+    ...
+    hyperBorder: {
+      borderAngle: '180deg',
       ...
     }
     ...

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports.decorateConfig = (config) => {
   var configObj = Object.assign({
     animate: false,
     borderWidth: '4px',
-    borderColors: ['#fc1da7', '#fba506']
+    borderColors: ['#fc1da7', '#fba506'],
+    borderAngle: '180deg'
   }, config.hyperBorder);
 
   var colors = getBorderColors(configObj.borderColors).join(',');
@@ -26,7 +27,7 @@ module.exports.decorateConfig = (config) => {
     css: `
       html {
         height: 100%;
-        background: linear-gradient(${ configObj.animate ? '269deg' : '180deg' }, ${colors});
+        background: linear-gradient(${ configObj.animate ? '269deg' : configObj.borderAngle }, ${colors});
         ${ configObj.animate ? animateStyles : '' }
         border-radius: ${borderWidth};
       }


### PR DESCRIPTION
This allows the user to configure the angle at which their linear gradient displays in the background. It adds a new key in the config object called borderAngle where users can specify the angle they want, which is defaulted to 180deg for compatibility's sake.