### PR TITLE
Adding ability to customize border colors depending on elevation status, and window focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module.exports = {
 
 Then every newly opened `Hyper` terminal window will have a different colored border.
 
-### Animate Border Colors
+### EXAMPLE: Animate Border Colors
 You like some animations? Then try this:
 
 ```javascript
@@ -93,7 +93,7 @@ module.exports = {
 }
 ```
 
-### Angled Gradients
+### EXAMPLE: Angled Gradients
 Because we use CSS3's `linear-gradient`, we're able to specify angles at which to create the radius. Set your own angle like this:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The following settings can be configured by adding a `hyperBorder` section in yo
 | `borderWidth`        | `string`             | CSS string for how thick the borders should be         |
 | `borderColors`       | `string`, `string[]` | The color(s) for the border                            |
 | `adminBorderColors`  | `string`, `string[]` | The color(s) for the border for an admin/elevated window. This follows the precedence  of `adminBorderColors` > `borderColors` > defaultColors                                    |
-| `blurredColors`      | `string`, `string[]` | The colors of the borders when the window isn't active |
-| `blurredAdminColors` | `string`, `string[]` | The colors of the borders when the admin/elevated window isn't active. This follows the precedence of `blurredAdminColors` > `blurredColors` > `adminBorderColors` > `borderColors` > defaultColors |
+| `blurredColors`      | `string`, `string[]` | The color(s) of the borders when the window isn't active |
+| `blurredAdminColors` | `string`, `string[]` | The color(s) of the borders when the admin/elevated window isn't active. This follows the precedence of `blurredAdminColors` > `blurredColors` > `adminBorderColors` > `borderColors` > defaultColors |
 
 ### EXAMPLE: Set Border Colors And Width
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,22 @@ module.exports = {
 then just restart `Hyper` app or go to the menu 'Plugins / Update All Now'
 
 ## Configuration
-### Set Border Colors And Width
-It is now possible to change the gradient colors and the border width.
+The following settings can be configured by adding a `hyperBorder` section in your `.hyper.js` `config` section:
 
-Just add the following to your `.hyper.js`:
+* `borderWidth`: string
+  * How thick the borders should be
+* `borderColors`: string, string[]
+  * The color of the borders
+* `adminBorderColors`: string, string[]
+  * The colors of the borders for an admin/elevated window
+  * This follows the precedence  of `adminBorderColors` > `borderColors` > defaultColors
+* `blurredColors`: string, string[]
+  * The colors of the borders when the window isn't active
+* `blurredAdminColors`: string, string[]
+  * The colors of the borders when the admin/elevated window isn't active
+  * This follows the precedence of `blurredAdminColors` > `blurredColors` > `adminBorderColors` > `borderColors` > defaultColors
+
+### EXAMPLE: Set Border Colors And Width
 
 ```javascript
 module.exports = {
@@ -34,7 +46,7 @@ module.exports = {
 }
 ```
 
-### Set Border Colors To Random Colors
+### EXAMPLE: Set Border Colors To Random Colors
 
 In addition, you can set any color value to `'random'` (string value):
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ The following settings can be configured by adding a `hyperBorder` section in yo
 | `blurredColors`      | `string`, `string[]` | The color(s) of the borders when the window isn't active |
 | `blurredAdminColors` | `string`, `string[]` | The color(s) of the borders when the admin/elevated window isn't active. This follows the precedence of `blurredAdminColors` > `blurredColors` > `adminBorderColors` > `borderColors` > defaultColors |
 
+## A note on admin/root colors
+The use of Hyper under the admin/root account is mainly intended for Windows' users (where it is common to run an application in
+elevated mode), since on Linux/OSX you would typically utilize the `sudo <command>` command. _Technically_ you can run Hyper as root
+on non-Windows machines (there are issues running Hyper as root under a [Wayland](https://wayland.freedesktop.org/) desktop), though
+in this case, the root user will actually have their own copy of `.hyper.js` configuration.
+
 ### EXAMPLE: Set Border Colors And Width
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+const {remote} = require('electron');
+const isElevated = require('is-elevated');
+
 const randomColor = ()  => '#'+Math.floor(Math.random()*16777215).toString(16);
 const getColor = (input) => input.toLowerCase() === 'random' ? randomColor() : input;
 
@@ -9,17 +12,41 @@ const getBorderColors = (colors = 'random') => {
   return colors.length < 2 ? colors.concat(colors[0]) : colors;
 }
 
+module.exports.onRendererWindow = (window) => {
+  const browserWindow = remote.getCurrentWindow();
+  browserWindow.on('blur', () => window.document.documentElement.classList.add('blurred'));
+  browserWindow.on('focus', () => window.document.documentElement.classList.remove('blurred'));
+
+  if (!browserWindow.isFocused()) {
+    window.document.documentElement.classList.add('blurred');
+  }
+
+  isElevated().then(elevated => {
+    if (elevated) {
+      window.document.documentElement.classList.add('elevated');
+    }
+  });
+}
+
 module.exports.decorateConfig = (config) => {
-  var configObj = Object.assign({
+  const defaultColors = ['#fc1da7', '#fba506'];
+
+  let configObj = Object.assign({
     animate: false,
     borderWidth: '4px',
-    borderColors: ['#fc1da7', '#fba506'],
+    borderColors: defaultColors,
+    adminBorderColors: config.hyperBorder.borderColors || defaultColors,
+    blurredAdminColors: config.hyperBorder.blurredColors || config.hyperBorder.adminBorderColors || defaultColors,
+    blurredColors: defaultColors,
     borderAngle: '180deg'
   }, config.hyperBorder);
 
-  var colors = getBorderColors(configObj.borderColors).join(',');
-  var borderWidth = configObj.borderWidth;
-  var animateStyles = `
+  let colors = getBorderColors(configObj.borderColors).join(',');
+  let adminColors = getBorderColors(configObj.adminBorderColors).join(',');
+  let blurredColors = getBorderColors(configObj.blurredColors).join(',');
+  let blurredAdminColors = getBorderColors(configObj.blurredAdminColors).join(',');
+  let borderWidth = configObj.borderWidth;
+  let animateStyles = `
     background-size: 800% 800%;
     animation: AnimationName 16s ease infinite;
   `
@@ -31,6 +58,15 @@ module.exports.decorateConfig = (config) => {
         ${ configObj.animate ? animateStyles : '' }
         border-radius: ${borderWidth};
         overflow: hidden;
+      }
+      html.elevated {
+        background: linear-gradient(${ configObj.animate ? '269deg' : configObj.borderAngle }, ${adminColors});
+      }
+      html.blurred {
+        background: linear-gradient(${ configObj.animate ? '269deg' : configObj.borderAngle }, ${blurredColors});
+      }
+      html.blurred.elevated {
+        background: linear-gradient(${ configObj.animate ? '269deg' : configObj.borderAngle }, ${blurredAdminColors});
       }
       @keyframes AnimationName {
           0%{background-position:0% 50%}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/webmatze/hyperborder.git"
   },
-  "dependencies": {}
+  "dependencies": {
+    "is-elevated": "^2.0.1"
+  }
 }


### PR DESCRIPTION
You can now configure the colors of admin windows, and configure the colors depending on if the window is active or not (addresses #15).

Example config
```js
hyperBorder: {
  borderWidth: "2px",
  adminBorderColors: "red",
  blurredColors: "black",
  blurredAdminColors: "darkred"
}
```
**Focused !admin**
![image](https://user-images.githubusercontent.com/3392349/32528346-615b1a4e-c3e7-11e7-95bf-ffdfddb84dd5.png)

**Blurred !admin**
![image](https://user-images.githubusercontent.com/3392349/32528341-5b5252ca-c3e7-11e7-9d04-9258f04895f1.png)

**Focused admin**
![image](https://user-images.githubusercontent.com/3392349/32528359-779f6710-c3e7-11e7-8ee2-b028728b6f25.png)

**!Focused admin**
![image](https://user-images.githubusercontent.com/3392349/32528366-83c937f0-c3e7-11e7-8b03-293b7c008eae.png)

