### PR TITLE
Fixing overflowing tab section border

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,10 @@ module.exports.decorateConfig = (config) => {
       .hyper_main .terms_term {
         margin-top: ${borderWidth};
       }
+      .header_windowHeaderWithBorder {
+        left: ${borderWidth};
+        width: calc(100% - ${borderWidth} - ${borderWidth});
+      }
     `
   });
 }


### PR DESCRIPTION
Currently the bottom border of the tab section overflows into the border injected by `hyperborder`. This adds the CSS to fix that.

Before:
![tab border](https://user-images.githubusercontent.com/3392349/32639228-b480414a-c577-11e7-99d5-7176ad8de134.png)

After:
![tab border fixed](https://user-images.githubusercontent.com/3392349/32639233-b832ecd4-c577-11e7-8b89-709bafedd27c.png)
