### PR TITLE
typo(README): invalid semicolon in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ module.exports = {
     ...
     hyperBorder: {
       animate: {
-        duration: '1s';   // default is 16s
+        duration: '1s',  // default is 16s
       },
       ...
     }


### PR DESCRIPTION
there was a typo (semicolon instead of comma) in example.