### PR TITLE
Allow setting the border radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The following settings can be configured by adding a `hyperBorder` section in yo
 | Setting              | Type                 | Description                                            |
 |----------------------|----------------------|--------------------------------------------------------|
 | `borderWidth`        | `string`             | CSS string for how thick the borders should be         |
-| `borderRadius`       | `string`             | CSS string for round the corners of an element's outer border edge |
+| `borderRadiusInner`  | `string`             | CSS string for round inner corners                     |
+| `borderRadiusOuter`  | `string`             | CSS string for round outer corners                     |
 | `borderColors`       | `string`, `string[]` | The color(s) for the border                            |
 | `adminBorderColors`  | `string`, `string[]` | The color(s) for the border for an admin/elevated window. This follows the precedence  of `adminBorderColors` > `borderColors` > defaultColors                                    |
 | `blurredColors`      | `string`, `string[]` | The color(s) of the borders when the window isn't active |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following settings can be configured by adding a `hyperBorder` section in yo
 | Setting              | Type                 | Description                                            |
 |----------------------|----------------------|--------------------------------------------------------|
 | `borderWidth`        | `string`             | CSS string for how thick the borders should be         |
+| `borderRadius`       | `string`             | CSS string for round the corners of an element's outer border edge |
 | `borderColors`       | `string`, `string[]` | The color(s) for the border                            |
 | `adminBorderColors`  | `string`, `string[]` | The color(s) for the border for an admin/elevated window. This follows the precedence  of `adminBorderColors` > `borderColors` > defaultColors                                    |
 | `blurredColors`      | `string`, `string[]` | The color(s) of the borders when the window isn't active |

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports.reduceUI = (state, {type, config}) => {
         animate: false,
         backgroundColor: config.backgroundColor,
         borderWidth: '4px',
+        borderRadius: '4px',
         borderColors: defaultColors,
         adminBorderColors: (config.hyperBorder && config.hyperBorder.borderColors) || defaultColors,
         blurredAdminColors: (config.hyperBorder && (config.hyperBorder.blurredColors || config.hyperBorder.adminBorderColors)) || defaultColors,
@@ -76,6 +77,7 @@ module.exports.decorateHyper = (Hyper, {React}) => {
         React.createElement('style', {}, `
         #hyperborder {
           --border-width: ${this.props.hyperBorder.borderWidth};
+          --border-radius: ${this.props.hyperBorder.borderRadius};
           ${this.props.hyperBorder.animate ? '' : '--border-angle: ' + this.props.hyperBorder.borderAngle + ';'}
           --background-color: ${this.props.hyperBorder.backgroundColor || '#000'};
           --border-colors: ${getBorderColors(this.props.hyperBorder.borderColors).join(',')};
@@ -88,7 +90,7 @@ module.exports.decorateHyper = (Hyper, {React}) => {
           left: 0;
           right: 0;
           position: fixed;
-          border-radius: var(--border-width);
+          border-radius: var(--border-radius);
         }
         #hyperborder .hyper_main {
           background-color: var(--background-color);
@@ -96,7 +98,7 @@ module.exports.decorateHyper = (Hyper, {React}) => {
           bottom: var(--border-width);
           left: var(--border-width);
           right: var(--border-width);
-          border-radius: var(--border-width);
+          border-radius: var(--border-radius);
         }
         #hyperborder .hyper_main .header_header {
           top: var(--border-width);

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ module.exports.reduceUI = (state, {type, config}) => {
         animate: false,
         backgroundColor: config.backgroundColor,
         borderWidth: '4px',
-        borderRadius: '4px',
+        borderRadiusInner: '4px',
+        borderRadiusOuter: '4px',
         borderColors: defaultColors,
         adminBorderColors: (config.hyperBorder && config.hyperBorder.borderColors) || defaultColors,
         blurredAdminColors: (config.hyperBorder && (config.hyperBorder.blurredColors || config.hyperBorder.adminBorderColors)) || defaultColors,
@@ -77,7 +78,8 @@ module.exports.decorateHyper = (Hyper, {React}) => {
         React.createElement('style', {}, `
         #hyperborder {
           --border-width: ${this.props.hyperBorder.borderWidth};
-          --border-radius: ${this.props.hyperBorder.borderRadius};
+          --border-radius-inner: ${this.props.hyperBorder.borderRadiusInner};
+          --border-radius-outer: ${this.props.hyperBorder.borderRadiusOuter};
           ${this.props.hyperBorder.animate ? '' : '--border-angle: ' + this.props.hyperBorder.borderAngle + ';'}
           --background-color: ${this.props.hyperBorder.backgroundColor || '#000'};
           --border-colors: ${getBorderColors(this.props.hyperBorder.borderColors).join(',')};
@@ -90,7 +92,7 @@ module.exports.decorateHyper = (Hyper, {React}) => {
           left: 0;
           right: 0;
           position: fixed;
-          border-radius: var(--border-radius);
+          border-radius: var(--border-radius-outer);
         }
         #hyperborder .hyper_main {
           background-color: var(--background-color);
@@ -98,7 +100,7 @@ module.exports.decorateHyper = (Hyper, {React}) => {
           bottom: var(--border-width);
           left: var(--border-width);
           right: var(--border-width);
-          border-radius: var(--border-radius);
+          border-radius: var(--border-radius-inner);
         }
         #hyperborder .hyper_main .header_header {
           top: var(--border-width);


### PR DESCRIPTION
Example config:
```js
hyperBorder: {
  borderWidth: '4px',
  borderRadiusInner: '6px', // for round inner corners
  borderRadiusOuter: '0', // for round outer corners
}
```

Resolves #47